### PR TITLE
Update PKGBUILD llama.cpp-vulkan added spirv-headers make dependency

### DIFF
--- a/packages/llama.cpp-vulkan/PKGBUILD
+++ b/packages/llama.cpp-vulkan/PKGBUILD
@@ -21,6 +21,7 @@ makedepends=(
   git
   shaderc
   vulkan-headers
+  spirv-headers
 )
 optdepends=(
   'python-numpy: needed for convert_hf_to_gguf.py'


### PR DESCRIPTION
llama.cpp-vulkan b7895 requires 'spirv-headers' in order to compile successfully.

Tested on 04-15-2026

llama.cpp-vulkan now compiles successfully