### PR TITLE
fix: pre-build webui with npm to fix missing Tailwind CSS

### DIFF
--- a/packages/llama.cpp-gfx1151/PKGBUILD
+++ b/packages/llama.cpp-gfx1151/PKGBUILD
@@ -20,6 +20,8 @@ depends=(
 makedepends=(
   cmake
   git
+  nodejs
+  npm
   shaderc
   vulkan-headers
   spirv-headers
@@ -55,6 +57,11 @@ prepare() {
 }
 
 build() {
+  pushd "${_pkgname}/tools/ui"
+  npm ci
+  npm run build
+  popd
+
   # 配置环境
   if [[ -z "${ROCM_PATH}" ]]; then
     source /etc/profile

--- a/packages/llama.cpp-hip/PKGBUILD
+++ b/packages/llama.cpp-hip/PKGBUILD
@@ -22,6 +22,8 @@ depends=(
 makedepends=(
   cmake
   git
+  nodejs
+  npm
   rocm-hip-sdk
 )
 optdepends=(
@@ -50,6 +52,11 @@ prepare() {
 }
 
 build() {
+  pushd "${_pkgname}/tools/ui"
+  npm ci
+  npm run build
+  popd
+
   if [[ -z "${ROCM_PATH}" ]]; then
     source /etc/profile
   fi

--- a/packages/llama.cpp-vulkan/PKGBUILD
+++ b/packages/llama.cpp-vulkan/PKGBUILD
@@ -19,6 +19,8 @@ depends=(
 makedepends=(
   cmake
   git
+  nodejs
+  npm
   shaderc
   vulkan-headers
   spirv-headers
@@ -49,6 +51,11 @@ prepare() {
 }
 
 build() {
+  pushd "${_pkgname}/tools/ui"
+  npm ci
+  npm run build
+  popd
+
   local _cmake_options=(
     -B build
     -S "${_pkgname}"


### PR DESCRIPTION
Since ggml-org/llama.cpp@253ba110b (webui: Move static build output from repo code to HF Bucket), the webui is no longer bundled in the source tree and must be built or downloaded at package build time.

When cmake builds it via execute_process, Tailwind v4's oxide scanner silently produces no utility classes — bundle.css ends up with only base/reset styles, so the UI renders completely unstyled.

The fix is to run npm ci && npm run build directly in build() before cmake. SvelteKit outputs to ../../build/tools/ui/dist (relative to tools/ui/), which is exactly the LOCAL_UI_DIR cmake checks first - so cmake picks up the pre-built assets and skips its own npm subprocess entirely.

Adds nodejs and npm to makedepends in all three llama.cpp packages.