### PR TITLE
fix: stop Tailwind oxide scanner from inheriting AUR .gitignore

### DIFF
--- a/packages/llama.cpp-gfx1151/PKGBUILD
+++ b/packages/llama.cpp-gfx1151/PKGBUILD
@@ -52,6 +52,14 @@ sha256sums=('5cd1b1da160c77dcbce41ffb5a3ee88f4149a51622bb37965f8e486d6db8c97c'
 prepare() {
   ln -sf "${_pkgname}-${pkgver}" llama.cpp
 
+  # Tailwind v4's oxide scanner walks up looking for the nearest .git to anchor
+  # .gitignore lookup. In AUR helpers (yay/paru) the parent .git is the AUR
+  # clone, whose .gitignore is `*` + an allowlist for PKGBUILD/.SRCINFO. That
+  # rule ignores tools/ui/src/lib/**/*.svelte, so Tailwind scans zero files and
+  # the built bundle.css ships without any utility classes. An empty .git in
+  # the extracted source tree stops the upward walk before that point.
+  mkdir -p "${_pkgname}/.git"
+
   # patch -d "${srcdir}/llama.cpp" -Np1 -i "${srcdir}/llama-gfx1151.patch"
 }
 

--- a/packages/llama.cpp-hip/PKGBUILD
+++ b/packages/llama.cpp-hip/PKGBUILD
@@ -49,6 +49,14 @@ sha256sums=('5cd1b1da160c77dcbce41ffb5a3ee88f4149a51622bb37965f8e486d6db8c97c'
 
 prepare() {
   ln -sf "${_pkgname}-${pkgver}" llama.cpp
+
+  # Tailwind v4's oxide scanner walks up looking for the nearest .git to anchor
+  # .gitignore lookup. In AUR helpers (yay/paru) the parent .git is the AUR
+  # clone, whose .gitignore is `*` + an allowlist for PKGBUILD/.SRCINFO. That
+  # rule ignores tools/ui/src/lib/**/*.svelte, so Tailwind scans zero files and
+  # the built bundle.css ships without any utility classes. An empty .git in
+  # the extracted source tree stops the upward walk before that point.
+  mkdir -p "${_pkgname}/.git"
 }
 
 build() {

--- a/packages/llama.cpp-vulkan/PKGBUILD
+++ b/packages/llama.cpp-vulkan/PKGBUILD
@@ -48,6 +48,14 @@ sha256sums=('5cd1b1da160c77dcbce41ffb5a3ee88f4149a51622bb37965f8e486d6db8c97c'
 
 prepare() {
   ln -sf "${_pkgname}-${pkgver}" llama.cpp
+
+  # Tailwind v4's oxide scanner walks up looking for the nearest .git to anchor
+  # .gitignore lookup. In AUR helpers (yay/paru) the parent .git is the AUR
+  # clone, whose .gitignore is `*` + an allowlist for PKGBUILD/.SRCINFO. That
+  # rule ignores tools/ui/src/lib/**/*.svelte, so Tailwind scans zero files and
+  # the built bundle.css ships without any utility classes. An empty .git in
+  # the extracted source tree stops the upward walk before that point.
+  mkdir -p "${_pkgname}/.git"
 }
 
 build() {


### PR DESCRIPTION
PR #8 moved the npm build into build() so cmake's execute_process wouldn't run it. That avoided the cmake subprocess but didn't change what npm produces - bundle.css is still ~404 KB with zero Tailwind utility classes.

## Root cause

Tailwind v4's @tailwindcss/oxide uses Rust's ignore crate, which walks up to the nearest .git and applies that repo's .gitignore. Under yay/paru, that's the AUR clone - whose .gitignore is * + an allowlist for PKGBUILD/.SRCINFO. The * rule ignores tools/ui/src/lib/**/*.svelte, oxide scans 0 files, Tailwind emits 0 utility classes.

## Fix

mkdir -p "${_pkgname}/.git" in prepare(). An empty .git halts the upward walk at the llama.cpp tree root, before it reaches the AUR clone.
A/B (same $srcdir, only difference is the .git boundary)

|	|bundle.css|.flex{|
|---|---|---|
|Before|404,432 B|0|
|After|505,965 B|1|

505,965 B is also the size of the Hugging Face prebuilt for this version.

## Notes
cmake/build-info.cmake runs git rev-parse from the source tree. An empty .git makes it fail with "not a git repository" - same as no .git at all (the tarball default). BUILD_COMMIT / BUILD_NUMBER defaults unchanged; PKGBUILD's -DLLAMA_BUILD_NUMBER already overrides anyway.
    Verified end-to-end via makepkg -o + npm run build in ~/.cache/yay/llama.cpp-vulkan/.