### PR TITLE
llama.cpp-vulkan: fix 7 npm audit vulnerabilities

### DIFF
--- a/packages/llama.cpp-vulkan/PKGBUILD
+++ b/packages/llama.cpp-vulkan/PKGBUILD
@@ -4,7 +4,7 @@
 pkgname=llama.cpp-vulkan
 _pkgname=${pkgname%%-vulkan}
 pkgver=b9297
-pkgrel=1
+pkgrel=2
 pkgdesc="Port of Facebook's LLaMA model in C/C++ (with Vulkan GPU optimizations)"
 arch=(x86_64 armv7h aarch64)
 url='https://github.com/ggml-org/llama.cpp'
@@ -56,11 +56,25 @@ prepare() {
   # the built bundle.css ships without any utility classes. An empty .git in
   # the extracted source tree stops the upward walk before that point.
   mkdir -p "${_pkgname}/.git"
+
+  # Inject npm overrides into tools/ui/package.json to fix audit vulnerabilities
+  # (cookie <0.7.0 via @sveltejs/kit, qs <6.15.2 via storybook stack).
+  python -c "
+import json, pathlib
+p = pathlib.Path('${_pkgname}/tools/ui/package.json')
+d = json.loads(p.read_text())
+d.setdefault('overrides', {})
+d['overrides']['cookie'] = '>=0.7.0'
+d['overrides']['qs'] = '>=6.15.2'
+p.write_text(json.dumps(d, indent=2) + '\n')
+"
 }
 
 build() {
   pushd "${_pkgname}/tools/ui"
-  npm ci
+  # Regenerate lockfile so it reflects the security overrides, then install.
+  npm install --package-lock-only
+  npm install --no-audit --no-fund
   npm run build
   popd
 


### PR DESCRIPTION
## What

Fix the 7 npm audit vulnerabilities (6 low + 1 moderate) raised during the `tools/ui` web UI build of `llama.cpp-vulkan`:

- `cookie <0.7.0` ([GHSA-pxg6-pf52-xh8x](https://github.com/advisories/GHSA-pxg6-pf52-xh8x)) — pulled via `@sveltejs/kit`
- `qs <6.15.2` ([GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26)) — pulled via the storybook stack

## How

- `prepare()`: inject an `overrides` block into `tools/ui/package.json` pinning the affected transitive deps to patched versions.
- `build()`: replace `npm ci` with `npm install --package-lock-only` + `npm install` so the regenerated lockfile reflects the overrides (`npm ci` would error out otherwise).
- Bumped `pkgrel` to 2.

## Verification

```
$ npm audit
found 0 vulnerabilities
```

Full build (`makepkg -f`) succeeds and the resulting package installs cleanly with `pacman -U`.